### PR TITLE
Manage ipsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Noddos is now up and running on Lede firmware installed on a a Linksys WRT 1200A
 	mkdir -p noddosbuild/package/{noddos,libtins}
 	cd noddosbuild
 	wget https://raw.githubusercontent.com/noddos/noddos/master/lede/packages/noddos/Makefile -O package/noddos/Makefile
-    wget https://raw.githubusercontent.com/noddos/noddos/master/lede/packages/libtins/Makefile  -O package/libtins/Makefile
+	wget https://raw.githubusercontent.com/noddos/noddos/master/lede/packages/libtins/Makefile  -O package/libtins/Makefile
 	ROOTDIR=$PWD
 
 Download the Lede project SDK v17.01.2 for your platform from [Lede Table of Hardware](https://lede-project.org/toh/start)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We need to modify the menu structure of the Luci web interface to point to the N
     	entry({"admin", "status", "clients"}, template("admin_status/clients"), _("Clients"), 3)
     end
 
-Then edit /usr/lib/lua/luci/controller/admin/network.lua, insert on line l16:
+Then edit /usr/lib/lua/luci/controller/admin/network.lua, insert on line 116:
 
     if nixio.fs.access("/usr/lib/lua/luci/model/cbi/admin_network/noddos.lua") then
         page = entry({"admin", "network", "noddos"}, cbi("admin_network/noddos"), nil)
@@ -79,11 +79,9 @@ Compilation instructions are available for Home Gateways and regular Linux syste
 Noddos is now up and running on Lede firmware installed on a a Linksys WRT 1200AC. There is also the package for Asus/Netgear/D-Link/Buffalo routers. If you have a HGW using a differnet platform then you can use these instructions to generate your own package. These instructions are based on the Lede 17.01.2 release.
 
 	mkdir -p noddosbuild/package/{noddos,libtins}
-	cd noddosbuild/package/noddos
-	wget https://github.com/noddos/noddos/blob/master/lede/packages/noddos/Makefile
-	cd ../libtins
-	wget https://github.com/noddos/noddos/blob/master/lede/packages/libtins/Makefile
-	cd ../..
+	cd noddosbuild
+	wget https://raw.githubusercontent.com/noddos/noddos/master/lede/packages/noddos/Makefile -O package/noddos/Makefile
+    wget https://raw.githubusercontent.com/noddos/noddos/master/lede/packages/libtins/Makefile  -O package/libtins/Makefile
 	ROOTDIR=$PWD
 
 Download the Lede project SDK v17.01.2 for your platform from [Lede Table of Hardware](https://lede-project.org/toh/start)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ In the firmware build menu:
 Then execute the following commands:
 
     ./scripts/feeds update -a
-    ./scripts/feeds install libtins
     ./scripts/feeds install noddos
     make menuconfig
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,8 +44,8 @@ include_directories("${PROJECT_BINARY_DIR}")
  
 add_executable(noddos noddos.cxx Host.cxx 
     HostCache.cxx SsdpServer.cxx SsdpLocation.cxx FlowTrack.cxx Config.cxx
-    opensslfingerprint.cxx PacketSnoop.cxx)
-target_link_libraries(noddos libnetfilter_conntrack.so ssl crypto curl tins)
+    opensslfingerprint.cxx PacketSnoop.cxx Ipset.cxx)
+target_link_libraries(noddos libnetfilter_conntrack.so ssl crypto curl tins ipset)
 
 enable_testing()
 
@@ -73,6 +73,10 @@ add_executable(Identifier_test Identifier_test.cxx)
 add_test (Config Config_test)
 add_executable(Config_test Config_test.cxx opensslfingerprint.cxx)
 target_link_libraries(Config_test curl ssl crypto)
+
+add_test (Ipset Ipset_test)
+add_executable(Ipset_test Ipset_test.cxx Ipset.cxx)
+target_link_libraries(Ipset_test ipset)
 
 add_test (SsdpServer SsdpServer_test)
 add_executable(SsdpServer_test SsdpServer_test.cxx 

--- a/src/Ipset.cxx
+++ b/src/Ipset.cxx
@@ -21,6 +21,8 @@
  */
 
 #include "Ipset.h"
+#include <iostream>
+#include <stdexcept>
 
 bool Ipset::try_cmd(enum ipset_cmd cmd, const struct in_addr *addr, uint32_t timeout) {
     int r = ipset_session_data_set(session, IPSET_SETNAME, setName.c_str());
@@ -54,17 +56,30 @@ bool Ipset::try_cmd(enum ipset_cmd cmd, const MacAddress &Mac, uint32_t timeout)
     // ipset_session_data_set(session, IPSET_OPT_ETHER, Mac.c_str());
     r = ipset_parse_elem(session, (ipset_opt)type->last_elem_optional, Mac.c_str());
     if (r < 0) {
-        printf("Can't call ipset_parse_elem, error: %d\n", r);
-        printf("Error: %s", ipset_session_error(session));
+        std::string e = "Can't call ipset_parse_elem, error: ";
+        e.append(ipset_session_error(session));
+        ipset_session_fini(session);
+        throw std::runtime_error(e.c_str());
+        return false;
     } else {
         if (timeout) {
             r = ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout);
             if (r != 0) {
-                r = ipset_cmd(session, cmd, 0);
+                std::string e = "Can't set timeout for " + setName + ", error: " + ipset_session_error(session);
+                ipset_session_fini(session);
+                throw std::runtime_error(e.c_str());
             }
         }
+        r = ipset_cmd(session, cmd, 0);
+        if (r != 0) {
+            std::string e = "Can't call ipset_cmd, error: ";
+            e.append(ipset_session_error(session));
+            ipset_session_fini(session);
+            throw std::runtime_error(e.c_str());
+            return false;
+        }
     }
-    // r = ipset_commit(session);
+    r = ipset_commit(session);
     /* assume that errors always occur if NOT in set. To do it otherwise,
      * see lib/session.c for IPSET_CMD_TEST in ipset_cmd */
     return r == 0;
@@ -86,6 +101,10 @@ bool Ipset::try_create() {
       ipset_session_data_set(session, IPSET_OPT_TYPE, setType.c_str());
       if (setType == "hash:ip") {
           uint8_t family = NFPROTO_IPV4;
+          ipset_session_data_set(session, IPSET_OPT_FAMILY, &family);
+      } else if (setType == "hash:mac") {
+          throw std::logic_error("Creating ipsets of type hash:mac not supported yet");
+          uint8_t family = NFPROTO_UNSPEC;
           ipset_session_data_set(session, IPSET_OPT_FAMILY, &family);
       }
       r = ipset_cmd(session, IPSET_CMD_CREATE, 0);

--- a/src/Ipset.cxx
+++ b/src/Ipset.cxx
@@ -1,0 +1,94 @@
+/*
+   Copyright 2017 Steven Hessing
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ * Ipset.cxx
+ *
+ *  Created on: Aug 9, 2017
+ *      Author: Steven HEssing
+ */
+
+#include "Ipset.h"
+
+bool Ipset::try_cmd(enum ipset_cmd cmd, const struct in_addr *addr, uint32_t timeout) {
+    int r = ipset_session_data_set(session, IPSET_SETNAME, setName.c_str());
+
+    const struct ipset_type *type = ipset_type_get(session, cmd);
+    if (type == NULL) {
+         return false;
+    }
+
+    uint8_t family = NFPROTO_IPV4;
+    ipset_session_data_set(session, IPSET_OPT_FAMILY, &family);
+    ipset_session_data_set(session, IPSET_OPT_IP, addr);
+    if (timeout) {
+        ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout);
+    }
+    r = ipset_cmd(session, cmd, 0);
+    /* assume that errors always occur if NOT in set. To do it otherwise,
+     * see lib/session.c for IPSET_CMD_TEST in ipset_cmd */
+    return r == 0;
+}
+
+bool Ipset::try_cmd(enum ipset_cmd cmd, const MacAddress &Mac, uint32_t timeout) {
+    int r;
+    r = ipset_session_data_set(session, IPSET_SETNAME, setName.c_str());
+
+    const struct ipset_type *type = ipset_type_get(session, cmd);
+    if (type == NULL) {
+         return false;
+    }
+    // ipset_parse_ether(session, IPSET_OPT_ETHER, Mac.c_str());
+    // ipset_session_data_set(session, IPSET_OPT_ETHER, Mac.c_str());
+    r = ipset_parse_elem(session, (ipset_opt)type->last_elem_optional, Mac.c_str());
+    if (r < 0) {
+        printf("Can't call ipset_parse_elem, error: %d\n", r);
+        printf("Error: %s", ipset_session_error(session));
+    } else {
+        if (timeout) {
+            r = ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout);
+            if (r != 0) {
+                r = ipset_cmd(session, cmd, 0);
+            }
+        }
+    }
+    // r = ipset_commit(session);
+    /* assume that errors always occur if NOT in set. To do it otherwise,
+     * see lib/session.c for IPSET_CMD_TEST in ipset_cmd */
+    return r == 0;
+}
+
+bool Ipset::try_create() {
+      const struct ipset_type *type;
+      int r;
+      r = ipset_session_data_set(session, IPSET_SETNAME, setName.c_str());
+      /* since the IPSET_SETNAME option is valid, this should never fail */
+      // assert(r == 0);
+      ipset_session_data_set(session, IPSET_OPT_TYPENAME, setType.c_str());
+      type = ipset_type_get(session, IPSET_CMD_CREATE);
+      if (type == NULL) {
+          return false;
+      }
+      uint32_t timeout = 0; /* timeout support, but default to infinity */
+      ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout);
+      ipset_session_data_set(session, IPSET_OPT_TYPE, setType.c_str());
+      if (setType == "hash:ip") {
+          uint8_t family = NFPROTO_IPV4;
+          ipset_session_data_set(session, IPSET_OPT_FAMILY, &family);
+      }
+      r = ipset_cmd(session, IPSET_CMD_CREATE, 0);
+      return r == 0;
+}
+

--- a/src/Ipset.cxx
+++ b/src/Ipset.cxx
@@ -87,8 +87,7 @@ bool Ipset::try_cmd(enum ipset_cmd cmd, const MacAddress &Mac, uint32_t timeout)
 
 bool Ipset::try_create() {
       const struct ipset_type *type;
-      int r;
-      r = ipset_session_data_set(session, IPSET_SETNAME, setName.c_str());
+      int r = ipset_session_data_set(session, IPSET_SETNAME, setName.c_str());
       /* since the IPSET_SETNAME option is valid, this should never fail */
       // assert(r == 0);
       ipset_session_data_set(session, IPSET_OPT_TYPENAME, setType.c_str());
@@ -104,8 +103,8 @@ bool Ipset::try_create() {
           ipset_session_data_set(session, IPSET_OPT_FAMILY, &family);
       } else if (setType == "hash:mac") {
           throw std::logic_error("Creating ipsets of type hash:mac not supported yet");
-          uint8_t family = NFPROTO_UNSPEC;
-          ipset_session_data_set(session, IPSET_OPT_FAMILY, &family);
+          // uint8_t family = NFPROTO_UNSPEC;
+          // ipset_session_data_set(session, IPSET_OPT_FAMILY, &family);
       }
       r = ipset_cmd(session, IPSET_CMD_CREATE, 0);
       return r == 0;

--- a/src/Ipset.h
+++ b/src/Ipset.h
@@ -63,10 +63,15 @@ public:
         if (!Exists() && !try_create()) {
             std::string e = "Failed to create " + setName + "(" + setType + "):" + ipset_session_error(session);
             throw std::runtime_error(e.c_str());
-            // fprintf(stderr, "Failed to create %s: %s\n", setname.c_str(),
-            //        ipset_session_error(session));
             ipset_session_fini(session);
         }
+        /* This was little trick to find out what the IPSET_OPT_FAMILY is for a hash:mac
+         *
+        struct ipset_data *data = ipset_session_data(session);
+        uint8_t * ptr = (uint8_t *) ipset_data_get (data, IPSET_OPT_FAMILY);
+        printf ("%d\n", *ptr);
+        */
+
     }
 
     ~Ipset(void) {
@@ -81,15 +86,21 @@ public:
          return try_cmd(IPSET_CMD_ADD, addr, timeout);
      }
 
-     bool Add(const MacAddress &Mac, time_t timeout = 2419200 ) {
+     bool Add(const MacAddress &Mac, time_t timeout = 7776000) {
          return try_cmd(IPSET_CMD_ADD, Mac, timeout);
      }
      bool Remove(const struct in_addr * addr) {
          return try_cmd(IPSET_CMD_DEL, addr, 0);
      }
+     bool Remove(const MacAddress &Mac) {
+         return try_cmd(IPSET_CMD_DEL, Mac, 0);
+     }
 
      bool In(const struct in_addr *addr) {
          return try_cmd(IPSET_CMD_TEST, addr, 0);
+     }
+     bool In(const MacAddress &Mac) {
+         return try_cmd(IPSET_CMD_TEST, Mac, 0);
      }
 
 };

--- a/src/Ipset.h
+++ b/src/Ipset.h
@@ -1,0 +1,97 @@
+/*
+   Copyright 2017 Steven Hessing
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ * Ipset.h
+ *
+ *  Created on: Aug 9, 2017
+ *      Author: Steven Hessing
+ */
+
+#ifndef IPSET_H_
+#define IPSET_H_
+
+#include <iostream>
+#include <stdexcept>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <libipset/linux_ip_set.h>
+#include <libipset/types.h>
+#include <libipset/session.h>
+
+#include "MacAddress.h"
+
+class Ipset {
+private:
+    struct ipset_session *session;
+    std::string setType;
+    std::string setName;
+
+    bool try_cmd(enum ipset_cmd cmd, const struct in_addr *addr, uint32_t timeout = 0);
+    bool try_cmd(enum ipset_cmd cmd, const MacAddress &Mac, uint32_t timeout = 0);
+    bool try_create();
+
+public:
+    Ipset(const std::string insetName, std::string insetType): setName{insetName}, setType{insetType} {
+        ipset_load_types();
+
+        session = ipset_session_init(printf);
+        if (!session) {
+            throw std::runtime_error("Can't initialize IPset session");
+        }
+
+        /* return success on attempting to add an existing / remove an
+         * non-existing rule */
+        ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL);
+
+        if (!Exists() && !try_create()) {
+            std::string e = "Failed to create " + setName + "(" + setType + "):" + ipset_session_error(session);
+            throw std::runtime_error(e.c_str());
+            // fprintf(stderr, "Failed to create %s: %s\n", setname.c_str(),
+            //        ipset_session_error(session));
+            ipset_session_fini(session);
+        }
+    }
+
+    ~Ipset(void) {
+        ipset_session_fini(session);
+    }
+    bool Exists() {
+         ipset_session_data_set(session, IPSET_SETNAME, setName.c_str());
+         return ipset_cmd(session, IPSET_CMD_HEADER, 0) == 0;
+     }
+
+     bool Add(const struct in_addr * addr, time_t timeout = 604800) {
+         return try_cmd(IPSET_CMD_ADD, addr, timeout);
+     }
+
+     bool Add(const MacAddress &Mac, time_t timeout = 2419200 ) {
+         return try_cmd(IPSET_CMD_ADD, Mac, timeout);
+     }
+     bool Remove(const struct in_addr * addr) {
+         return try_cmd(IPSET_CMD_DEL, addr, 0);
+     }
+
+     bool In(const struct in_addr *addr) {
+         return try_cmd(IPSET_CMD_TEST, addr, 0);
+     }
+
+};
+
+#endif /* IPSET_H_ */

--- a/src/Ipset_test.cxx
+++ b/src/Ipset_test.cxx
@@ -23,12 +23,18 @@
 #include "Ipset.h"
 #include "MacAddress.h"
 
+#include <unistd.h>
+#include <sys/types.h>
+
 int main(int argc, char** argv) {
     bool testfailed = false;
+    if (geteuid() != 0) {
+        std::cout << "Skipping ipset test as we're not running as root" << std::endl;
+        return 0;
+    }
     Ipset i("noddostest", "hash:ip");
     struct in_addr sin;
     inet_aton ("192.168.1.1", &sin);
-
     if (i.Add(&sin) == false ) {
         testfailed = 1;
         std::cout << "Failed to add IP address to hash:ip ipset" << std::endl;
@@ -43,7 +49,8 @@ int main(int argc, char** argv) {
             }
         }
     }
-    Ipset m("noddosmac", "hash:mac");
+    // disable hash:mac test as it requires an existing ipset hash:map to exist
+    /* Ipset m("noddosmac", "hash:mac");
     MacAddress Mac("AA:BB:CC:DD:EE:FF");
     if (m.Add(Mac) == false ) {
         testfailed = 1;
@@ -60,5 +67,6 @@ int main(int argc, char** argv) {
         }
     }
     return testfailed;
+    */
 }
 

--- a/src/Ipset_test.cxx
+++ b/src/Ipset_test.cxx
@@ -44,10 +44,20 @@ int main(int argc, char** argv) {
         }
     }
     Ipset m("noddosmac", "hash:mac");
-    MacAddress Mac("aa:bb:cc:dd:ee:ff");
+    MacAddress Mac("AA:BB:CC:DD:EE:FF");
     if (m.Add(Mac) == false ) {
         testfailed = 1;
         std::cout << "Failed to add MAC address to hash:mac ipset" << std::endl;
+    } else {
+        if (m.In(Mac) == false) {
+            testfailed = 1;
+            std::cout << "Couldn't find MAC address in hash:mac ipset" << std::endl;
+        } else {
+            if (m.Remove(Mac) == false) {
+                testfailed = 1;
+                std::cout << "Couldn't remove MAC address from hash:mac ipset" << std::endl;
+            }
+        }
     }
     return testfailed;
 }

--- a/src/Ipset_test.cxx
+++ b/src/Ipset_test.cxx
@@ -1,0 +1,54 @@
+/*
+   Copyright 2017 Steven Hessing
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ * Ipset_test.cxx
+ *
+ *  Created on: Aug 9, 2017
+ *      Author: Steven Hessing
+ */
+
+#include "Ipset.h"
+#include "MacAddress.h"
+
+int main(int argc, char** argv) {
+    bool testfailed = false;
+    Ipset i("noddostest", "hash:ip");
+    struct in_addr sin;
+    inet_aton ("192.168.1.1", &sin);
+
+    if (i.Add(&sin) == false ) {
+        testfailed = 1;
+        std::cout << "Failed to add IP address to hash:ip ipset" << std::endl;
+    } else {
+        if (i.In(&sin) == false) {
+            testfailed = 1;
+            std::cout << "Couldn't find IP address in hash:ip ipset" << std::endl;
+        } else {
+            if (i.Remove(&sin) == false) {
+                testfailed = 1;
+                std::cout << "Couldn't remove IP address from hash:ip ipset" << std::endl;
+            }
+        }
+    }
+    Ipset m("noddosmac", "hash:mac");
+    MacAddress Mac("aa:bb:cc:dd:ee:ff");
+    if (m.Add(Mac) == false ) {
+        testfailed = 1;
+        std::cout << "Failed to add MAC address to hash:mac ipset" << std::endl;
+    }
+    return testfailed;
+}
+


### PR DESCRIPTION
Add Ipset class. Add/Remove/In work for both hash:ip and hash:mac. Creation of hash:mac set still fails



