### PR TITLE
Fix compilation with openssl 1.1.0

### DIFF
--- a/src/opensslfingerprint.cxx
+++ b/src/opensslfingerprint.cxx
@@ -110,7 +110,9 @@ std::string getCertFingerprint(const std::string certfile, const bool Debug = fa
 	snprintf(&fpbuf[57], 3, "%02x", md[19]);
 
 	if (Debug) {
-		syslog (LOG_DEBUG, "Cert: %s, fingerprint: %s", x->name, fpbuf);
+		char *namebuf = X509_NAME_oneline(X509_get_subject_name(x),NULL,0);
+		syslog (LOG_DEBUG, "Cert: %s, fingerprint: %s", namebuf, fpbuf);
+		free(namebuf);
 	}
 
 	std::string fp = fpbuf;


### PR DESCRIPTION
X509 struct is opaque in openssl 1.1.0, but there was a debug message that used the struct member, and had to be changed to function calls.  Even though `X509_NAME_oneline()` is defined as legacy (but not deprecated) function in openssl doc, that's what openssl 1.0.2 uses to generate X509->name.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>