### PR TITLE
Ipset.cxx: update libipset API to version 7

### DIFF
--- a/src/Ipset.cxx
+++ b/src/Ipset.cxx
@@ -89,50 +89,46 @@ void Ipset::Open (const std::string inIpsetName, std::string inIpsetType, bool i
     DLOG_IF(INFO, Debug) << "opening instance " << inIpsetName << " of type " << inIpsetType;
     ipset_load_types();
 
-    struct ipset_session *session = ipset_session_init(printf);
+    struct ipset_session *session = noddos_ipset_session_init();
     if (session == nullptr) {
         LOG(ERROR) << "Cannot initialize ipset session.";
         ipset_session_fini(session);
         throw std::runtime_error ("Cannot initialize ipset session.");
     }
 
-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
-        LOG(ERROR) << "Can't set environment option.";
-        ipset_session_fini(session);
-        throw std::runtime_error ("Can't set environment option.");
-    }
+    ipset_envopt_set(session, IPSET_ENV_EXIST);
     int r = ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str());
     if ( r < 0) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << ": "  << ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << ": "  << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
     } else if (r > 0) {
         DLOG_IF(INFO, Debug) << "Not creating set " << ipsetName << " as it already exists";
         ipset_session_fini(session);
         return;
     }
     if (ipset_session_data_set(session, IPSET_OPT_TYPENAME, ipsetType.c_str()) < 0) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << " to type " << ipsetType << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << " to type " << ipsetType << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set type " + ipsetType + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't set type " + ipsetType + ": " + ipset_session_report_msg(session));
     }
     const struct ipset_type *type = ipset_type_get(session, IPSET_CMD_CREATE);
     if (type == NULL) {
-        LOG(ERROR) << "Can't set create ip " << ipsetName << ": %s" << ipset_session_error(session);
+        LOG(ERROR) << "Can't set create ip " << ipsetName << ": %s" << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't create ipset " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't create ipset " + ipsetName + ": " + ipset_session_report_msg(session));
     }
 
     uint32_t timeout = 0; /* default to infinity */
     if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) < 0) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << " to timeout " << timeout << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << " to timeout " << timeout << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set time-out " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't set time-out " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     if (ipset_session_data_set(session, IPSET_OPT_TYPE, type)) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << " option type: " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << " option type: " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set ipset type: " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't set ipset type: " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     uint8_t family = 0;
     if (ipsetType == "hash:ip" && isIpsetv4 == true) {
@@ -146,20 +142,20 @@ void Ipset::Open (const std::string inIpsetName, std::string inIpsetType, bool i
         throw std::invalid_argument("Unknown ipset data type " + ipsetType);
     }
     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << " address family "  << family << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << " address family "  << family << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Cannot set ipset family: " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Cannot set ipset family: " + ipsetName + ": " + ipset_session_report_msg(session));
     }
 
     if (ipset_cmd(session, IPSET_CMD_CREATE, /*lineno*/ 0) != 0) {
-        LOG(ERROR) << "Can't create setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't create setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Failed to create ipset " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Failed to create ipset " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     if (ipset_commit(session) < 0) {
-        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     ipset_session_fini(session);
 }
@@ -170,33 +166,29 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd) {
     if (Debug == true) {
         DLOG_IF(INFO, Debug) << "received command " << cmd << " for ipset " << ipsetName;
     }
-    struct ipset_session *session = ipset_session_init(printf);
+    struct ipset_session *session = noddos_ipset_session_init();
     if (session == nullptr) {
         LOG(ERROR) << "Cannot initialize ipset session.";
         ipset_session_fini(session);
         throw std::runtime_error ("Cannot initialize ipset session.");
     }
 
-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
-        LOG(ERROR) << "Can't set environment option.";
-        ipset_session_fini(session);
-        throw std::runtime_error ("Can't set environment option.");
-    }
+    ipset_envopt_set(session, IPSET_ENV_EXIST);
     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
     }
 
     if (ipset_cmd(session, cmd, 0) != 0) {
         ipset_session_fini(session);
-        LOG(ERROR) << "Can't exec ipset cmd for setname " << ipsetName << ": " << ipset_session_error(session);
-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
+        LOG(ERROR) << "Can't exec ipset cmd for setname " << ipsetName << ": " << ipset_session_report_msg(session);
+        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     if (ipset_commit(session) < 0) {
-        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     ipset_session_fini(session);
     return true;
@@ -207,61 +199,57 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd,  const Tins::IPv4Address &inIpAddress
     if (Debug == true) {
         DLOG_IF(INFO, Debug) << "received command " << cmd << " for IP address " << inIpAddress << " for ipset " << ipsetName;
     }
-    struct ipset_session *session = ipset_session_init(printf);
+    struct ipset_session *session = noddos_ipset_session_init();
     if (session == nullptr) {
         LOG(ERROR) << "Cannot initialize ipset session.";
         ipset_session_fini(session);
         throw std::runtime_error ("Cannot initialize ipset session.");
     }
 
-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
-        LOG(ERROR) << "Can't set environment option.";
-        ipset_session_fini(session);
-        throw std::runtime_error ("Can't set environment option.");
-    }
+    ipset_envopt_set(session, IPSET_ENV_EXIST);
     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << ": %s", ipsetName.c_str(), ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << ": %s", ipsetName.c_str(), ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     const struct ipset_type *type = ipset_type_get(session, cmd);
     if (type == NULL) {
-        LOG(ERROR) << "Can't get type for set " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't get type for set " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
     }
 
     uint8_t family = NFPROTO_IPV4;
     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
-        LOG(ERROR) << "Can't set session data to IPv4 family for set " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set session data to IPv4 family for set " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv4 family, error: " + ipset_session_error(session));
+        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv4 family, error: " + ipset_session_report_msg(session));
     }
     struct in_addr sin;
     inet_aton (inIpAddress.to_string().c_str(), &sin);
     if (ipset_session_data_set(session, IPSET_OPT_IP, &sin) < 0) {
-        LOG(ERROR) << "Can't set session data to the IPv4 address for setname " << ipsetName << ": %s", ipsetName.c_str(), ipset_session_error(session);
+        LOG(ERROR) << "Can't set session data to the IPv4 address for setname " << ipsetName << ": %s", ipsetName.c_str(), ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_error(session));
+        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_report_msg(session));
     }
 
     if (timeout) {
         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
-            LOG(ERROR) << "Can't set timeout for setname " << ipsetName << ": %s", ipsetName.c_str(), ipset_session_error(session);
+            LOG(ERROR) << "Can't set timeout for setname " << ipsetName << ": %s", ipsetName.c_str(), ipset_session_report_msg(session);
             ipset_session_fini(session);
-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
+            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
             return false;
         }
     }
     if (ipset_cmd(session, cmd, 0) != 0) {
         ipset_session_fini(session);
-        LOG(ERROR) << "Can't exec ipset cmd for setname " << ipsetName << ": " << ipset_session_error(session);
-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
+        LOG(ERROR) << "Can't exec ipset cmd for setname " << ipsetName << ": " << ipset_session_report_msg(session);
+        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     if (ipset_commit(session) < 0) {
-        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     ipset_session_fini(session);
     return true;
@@ -271,61 +259,57 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd,  const Tins::IPv6Address &inIpAddress
     if (Debug == true) {
         DLOG_IF(INFO, Debug) << "received command " << cmd << " for IP address " << inIpAddress << " for ipset " << ipsetName;
     }
-    struct ipset_session *session = ipset_session_init(printf);
+    struct ipset_session *session = noddos_ipset_session_init();
     if (session == nullptr) {
         PLOG(ERROR) << "Cannot initialize ipset session.";
         ipset_session_fini(session);
         throw std::runtime_error ("Cannot initialize ipset session.");
     }
 
-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
-        LOG(ERROR) << "Can't set environment option.";
-        ipset_session_fini(session);
-        throw std::runtime_error ("Can't set environment option.");
-    }
+    ipset_envopt_set(session, IPSET_ENV_EXIST);
     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << ": " <<  ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << ": " <<  ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     const struct ipset_type *type = ipset_type_get(session, cmd);
     if (type == NULL) {
-        LOG(ERROR) << "Can't get type for set " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't get type for set " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
     }
 
     uint8_t family = NFPROTO_IPV6;
     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
-        LOG(ERROR) << "Can't set session data to IPv6 family for set " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set session data to IPv6 family for set " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv6 family, error: " + ipset_session_error(session));
+        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv6 family, error: " + ipset_session_report_msg(session));
     }
 
     unsigned char buf[sizeof(struct in6_addr)];
     int s = inet_pton(AF_INET6, inIpAddress.to_string().c_str(), buf);
     if (ipset_session_data_set(session, IPSET_OPT_IP, &buf) < 0) {
-        LOG(ERROR) << "Can't set session data to the IPv4 address for setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set session data to the IPv4 address for setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_error(session));
+        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_report_msg(session));
     }
 
     if (timeout) {
         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
-            LOG(ERROR) << "Can't set timeout for setname " << ipsetName << ": %s" << ipset_session_error(session);
+            LOG(ERROR) << "Can't set timeout for setname " << ipsetName << ": %s" << ipset_session_report_msg(session);
             ipset_session_fini(session);
-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
+            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
         }
     }
     if (ipset_cmd(session, cmd, 0) != 0) {
-        LOG(ERROR) << "Can't exec ipset cmd for setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't exec ipset cmd for setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     if (ipset_commit(session) < 0) {
-        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     ipset_session_fini(session);
     return true;
@@ -336,50 +320,46 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd, const std::string Mac, time_t timeout
         DLOG_IF(INFO, Debug) << "received command " << cmd << " for MAC address " << Mac
                 << " for ipset " << ipsetName;
     }
-    struct ipset_session *session = ipset_session_init(printf);
+    struct ipset_session *session = noddos_ipset_session_init();
     if (session == nullptr) {
         PLOG(ERROR) << "Cannot initialize ipset session.";
         ipset_session_fini(session);
         throw std::runtime_error ("Cannot initialize ipset session.");
     }
 
-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
-        PLOG(ERROR) << "Can't set environment option.";
-        ipset_session_fini(session);
-        throw std::runtime_error ("Can't set environment option.");
-    }
+    ipset_envopt_set(session, IPSET_ENV_EXIST);
     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
-        LOG(ERROR) << "Can't set setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't set setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     const struct ipset_type *type = ipset_type_get(session, cmd);
     if (type == NULL) {
-        LOG(ERROR) << "Can't get type for set " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't get type for set " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     if (ipset_parse_elem(session, (ipset_opt)type->last_elem_optional, Mac.c_str()) < 0) {
-        LOG(ERROR) << "Can't call ipset_parse_elem for " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't call ipset_parse_elem for " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't call ipset_parse_elem for ipset " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't call ipset_parse_elem for ipset " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     if (timeout) {
         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
-            LOG(ERROR) << "Can't set timeout for setname " << ipsetName << ": " << ipset_session_error(session);
+            LOG(ERROR) << "Can't set timeout for setname " << ipsetName << ": " << ipset_session_report_msg(session);
             ipset_session_fini(session);
-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
+            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
         }
     }
     if (ipset_cmd(session, cmd, 0) != 0) {
-        LOG(ERROR) << "Can't exec ipset cmd for setname " << ipsetName << ": " << ipset_session_error(session);
+        LOG(ERROR) << "Can't exec ipset cmd for setname " << ipsetName << ": " << ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     if (ipset_commit(session) < 0) {
-        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": %s", ipsetName.c_str(), ipset_session_error(session);
+        LOG(ERROR) << "Can't commit for setname " << ipsetName << ": %s", ipsetName.c_str(), ipset_session_report_msg(session);
         ipset_session_fini(session);
-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
+        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
     }
     ipset_session_fini(session);
     return true;


### PR DESCRIPTION
Old API compatibility was kept with a compatibility shim.  The changes are not 100% innocuous.

The changed functions are:
* `ipset_session_error` was changed to `ipset_session_report_msg`.  IIRC, the new function groups functionality of `ipset_session_warning` so it will print warning messages as well. This should not be too bad.
* `ipsession_init` definition was changed from `struct ipset_session *ipset_session_init(ipset_outfn outfn)` to `struct ipset_session *ipset_session_init(ipset_print_outfn outfn, void *p)` in 7.1.  If `outfn` is `NULL`, `printf` is used.  Since the function name is the same, I added a `noddos_ipset_session_init(void)` call, and defined it with the semantics for either version.
* `ipset_envopt_parse` also changed semantics, but it uses a new `struct ipset` instead of `ipset_session`.  Looking at the ipset code, I decided to change the call to use `ipset_envopt_set`, a void function.  Therefore, I had to take out the error checking code.  If you look at the implementation of `ipset_envopt_parse`, you'll see the only possibility for an error is if you pass a bad `opt`.  The `opt` parameter is `IPSET_ENV_EXIST` for all calls in noddos, so the error condition would never be reached anyway.

This was tested, in version 0.5.5, with openwrt master, in a Linksys wrt3200acm.  I checked it runs, reports clients, generates a `DeviceDump.json` upon sendig `SIGUSR1`; however, it apparently fails to upload data:
```
Mar 19 18:16:08 xxx /usr/sbin/noddos[31626]: Noddos: Processing signal event SIGUSR2
Mar 19 18:16:08 xxx /usr/sbin/noddos[31626]: HostCache: Called v1/uploaddevices API with for 8 devices
Mar 19 18:16:08 xxx /usr/sbin/noddos[31626]: HostCache: Not calling v1/uploadstats API as there is no data to report
```
I'm not sure if this has anything to do with ipset.  I ran the `Ipset_test`, and it passed OK.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>